### PR TITLE
feat: add cleanup when stopping/restarting the resource

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,6 +1,8 @@
 const xmasTreeHash = GetHashKey('prop_xmas_ext');
 const xmasTreeOrigin = [240.82095336914062, -880.853515625, 28.792084503173828];
 
+let treeEntity;
+
 on('onClientResourceStart', (resource) => {
     if (resource === 'snow') {
         SetOverrideWeather('XMAS');
@@ -20,7 +22,7 @@ on('onClientResourceStart', (resource) => {
             const waitInterval = setInterval(() => {
                 if (HasModelLoaded(xmasTreeHash)) {
                     clearInterval(waitInterval);
-                    const treeEntity = CreateObject(xmasTreeHash, ...xmasTreeOrigin, false, false, false);
+                    treeEntity = CreateObject(xmasTreeHash, ...xmasTreeOrigin, false, false, false);
                     FreezeEntityPosition(treeEntity, true);
                     console.log('[snow] xmas tree spawned');
                 }
@@ -44,9 +46,9 @@ on('onResourceStop', (resource) => {
         RemoveNamedPtfxAsset('core_snow');
 
         if (GetConvar('snow_spawnTree', 'true').match(/^("true"|true)$/i)) {
-            if (HasModelLoaded(xmasTreeHash)) {
+            if (DoesEntityExist(treeEntity)) {
+                DeleteObject(treeEntity);
                 SetModelAsNoLongerNeeded(xmasTreeHash);
-                DeleteObject(xmasTreeHash);
                 console.log('[snow] xmas tree removed');
             }
         }

--- a/client.js
+++ b/client.js
@@ -1,3 +1,4 @@
+const xmasTreeHash = GetHashKey('prop_xmas_ext');
 const xmasTreeOrigin = [240.82095336914062, -880.853515625, 28.792084503173828];
 
 on('onClientResourceStart', (resource) => {
@@ -6,7 +7,7 @@ on('onClientResourceStart', (resource) => {
         SetSnowLevel(1);
 
         // I don't actually have a clue if this does anything in GTAV but hell it doesn't break anything neither so...
-        LoadCloudHat('Snowy 01', 1);
+        //LoadCloudHat('Snowy 01', 1);
 
         SetForcePedFootstepsTracks(true);
         SetForceVehicleTrails(true);
@@ -14,7 +15,6 @@ on('onClientResourceStart', (resource) => {
         RequestNamedPtfxAsset('core_snow');
 
         if (GetConvar('snow_spawnTree', 'true').match(/^("true"|true)$/i)) {
-            const xmasTreeHash = GetHashKey('prop_xmas_ext');
             RequestModel(xmasTreeHash);
 
             const waitInterval = setInterval(() => {
@@ -26,5 +26,30 @@ on('onClientResourceStart', (resource) => {
                 }
             }, 1500);
         }
+        console.log('[snow] snow enabled');
+    }
+});
+
+on('onResourceStop', (resource) => {
+    if (resource === 'snow') {
+        ClearOverrideWeather();
+        SetSnowLevel(-1.0);
+
+        // Calling this native seems to crash the script no matter how it's used. It's only used 4 times in the whole game, it could be just buggered.
+        //UnloadCloudHat('Snowy 01', 1); 
+
+        SetForcePedFootstepsTracks(false);
+        SetForceVehicleTrails(false);
+        SetRainLevel(0.0);
+        RemoveNamedPtfxAsset('core_snow');
+
+        if (GetConvar('snow_spawnTree', 'true').match(/^("true"|true)$/i)) {
+            if (HasModelLoaded(xmasTreeHash)) {
+                SetModelAsNoLongerNeeded(xmasTreeHash);
+                DeleteObject(xmasTreeHash);
+                console.log('[snow] xmas tree removed');
+            }
+        }
+        console.log('[snow] snow disabled');
     }
 });

--- a/client.js
+++ b/client.js
@@ -42,7 +42,7 @@ on('onResourceStop', (resource) => {
 
         SetForcePedFootstepsTracks(false);
         SetForceVehicleTrails(false);
-        SetRainLevel(0.0);
+        SetRainLevel(-1.0);
         RemoveNamedPtfxAsset('core_snow');
 
         if (GetConvar('snow_spawnTree', 'true').match(/^("true"|true)$/i)) {


### PR DESCRIPTION
This PR adds handling and clean-up for when stopping or restarting the resource. If an issue ever cropped up where the resource needed to be disabled, the snow and its effects would persist because they need to be explicitly removed.

Additionally, `LoadCloudHat` was commented out not only because forcing the Xmas weather seems to already apply the correct cloudhat, but because the cloud hat cannot be unloaded without the `UnloadCloudHat` native throwing an execution error. Considering it was allegedly only used 4 times in the game's scripts, I feel like the whole thing may be unnecessary.

The effects would also not be removed at all if I used `onClientResourceStop`, so I used `onResourceStop` which according to the docs executes \*while* the resource stops, which might be more desirable.